### PR TITLE
Normalize dynamically created classes by CGLIB to their canonical form

### DIFF
--- a/src/main/java/com/mysema/codegen/support/ClassUtils.java
+++ b/src/main/java/com/mysema/codegen/support/ClassUtils.java
@@ -66,9 +66,15 @@ public final class ClassUtils {
             return Collection.class;
         } else if (Map.class.isAssignableFrom(clazz)) {
             return Map.class;
-        } else {
-            return clazz;
+        // check for CGLIB generated classes
+        } else if (clazz.getName().contains("$$")) {
+            Class<?> zuper = clazz.getSuperclass();
+            if (zuper != null && !Object.class.equals(zuper)) {
+                return zuper;
+            }
         }
+
+        return clazz;
     }
 
     private ClassUtils() {


### PR DESCRIPTION
This fixes following issue (occuring in QueryDSL):

Q_2045977532_1275614662_1275614662.java:3: error: cannot find symbol
    public example.ExampleClass$$EnhancerByMockitoWithCGLIB$$45c738ca a1;
                  ^
  symbol:   class ExampleClass$$EnhancerByMockitoWithCGLIB$$45c738ca
  location: package example

As this class is dynamically generated, it can't be found at compile-time.
Because it basically is a proxy for the underlying object, use its super class
as normalized form, which solves the compile error.
