### PR TITLE
Fix codegen when using SureFire Booter combined with JaCoCo

### DIFF
--- a/src/main/java/com/mysema/codegen/SimpleCompiler.java
+++ b/src/main/java/com/mysema/codegen/SimpleCompiler.java
@@ -41,11 +41,21 @@ import com.google.common.base.Joiner;
 public class SimpleCompiler implements JavaCompiler {
 
     private static final Joiner pathJoiner = Joiner.on(File.pathSeparator);
-    
+
+    private static boolean isSureFireBooter(URLClassLoader cl) {
+        for (URL url : cl.getURLs()) {
+            if (url.getPath().contains("surefirebooter")) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
     public static String getClassPath(URLClassLoader cl) {
         try {
             List<String> paths = new ArrayList<String>();
-            if (cl.getURLs().length == 1 && cl.getURLs()[0].getPath().contains("surefirebooter")) {
+            if (isSureFireBooter(cl)) {
                 // extract MANIFEST.MF Class-Path entry, since the Java Compiler doesn't handle
                 // manifest only jars in the classpath correctly
                 URL url = cl.findResource("META-INF/MANIFEST.MF");


### PR DESCRIPTION
When using codegen with SureFire Booter + JaCoCo, codegen was unable to
determine the correct classpath, as its check for SureFire Booter was too
strict (both the surefirebooter and jacoco jars were on the cp, while the
code was only expecting surefirebooter).

Fix this in a more generic way by checking all classloader URLs for
surefirebooter.
