### PR TITLE
Fix Scala constructor to output "def this(...)" instead of "public <CLASSNAME>(...)"

### DIFF
--- a/src/main/java/com/mysema/codegen/ScalaWriter.java
+++ b/src/main/java/com/mysema/codegen/ScalaWriter.java
@@ -74,6 +74,8 @@ public class ScalaWriter extends AbstractCodeWriter<ScalaWriter> {
 
     private static final String VAL = "val ";
 
+    private static final String THIS = "this";
+
     private static final String TRAIT = "trait ";
 
     private final Set<String> classes = new HashSet<String>();
@@ -253,13 +255,13 @@ public class ScalaWriter extends AbstractCodeWriter<ScalaWriter> {
     @Override
     public <T> ScalaWriter beginConstructor(Collection<T> parameters,
             Function<T, Parameter> transformer) throws IOException {
-        beginLine(PUBLIC + type.getSimpleName()).params(parameters, transformer).append(" {").nl();
+        beginLine(DEF + THIS).params(parameters, transformer).append(" {").nl();
         return goIn();
     }
 
     @Override
     public ScalaWriter beginConstructor(Parameter... params) throws IOException {
-        beginLine(PUBLIC + type.getSimpleName()).params(params).append(" {").nl();
+        beginLine(DEF + THIS).params(params).append(" {").nl();
         return goIn();
     }
 

--- a/src/test/java/com/mysema/codegen/ScalaWriterTest.java
+++ b/src/test/java/com/mysema/codegen/ScalaWriterTest.java
@@ -377,7 +377,7 @@ public class ScalaWriterTest {
 
         System.out.println(w);
 
-        assertTrue(w.toString().contains("public JavaWriterTest(a: Int) {"));
+        assertTrue(w.toString().contains("def this(a: Int) {"));
     }
 
     @Test


### PR DESCRIPTION
Gets Scala code generation of com.mysema.query.jpa.codegen.HibernateDomainExporter a bit closer to being right.
