### PR TITLE
Add CodeWriter.getClassConstant() to abstract the difference between A.class in Java and classOf[A] in Scala.

### DIFF
--- a/src/main/java/com/mysema/codegen/CodeWriter.java
+++ b/src/main/java/com/mysema/codegen/CodeWriter.java
@@ -33,6 +33,8 @@ public interface CodeWriter extends Appendable {
 
     String getGenericName(boolean asArgType, Type type);
 
+    String getClassConstant(String className);
+
     CodeWriter annotation(Annotation annotation) throws IOException;
 
     CodeWriter annotation(Class<? extends Annotation> annotation) throws IOException;

--- a/src/main/java/com/mysema/codegen/JavaWriter.java
+++ b/src/main/java/com/mysema/codegen/JavaWriter.java
@@ -303,6 +303,12 @@ public final class JavaWriter extends AbstractCodeWriter<JavaWriter> {
                         + value + SEMICOLON).nl();
     }
 
+
+    @Override
+    public String getClassConstant(String className) {
+        return className + ".class";
+    }
+
     @Override
     public String getGenericName(boolean asArgType, Type type) {
         return type.getGenericName(asArgType, packages, classes);

--- a/src/main/java/com/mysema/codegen/ScalaWriter.java
+++ b/src/main/java/com/mysema/codegen/ScalaWriter.java
@@ -353,6 +353,11 @@ public class ScalaWriter extends AbstractCodeWriter<ScalaWriter> {
     }
 
     @Override
+    public String getClassConstant(String className) {
+        return "classOf[" + className + "]";
+    }
+
+    @Override
     public String getGenericName(boolean asArgType, Type type) {
         if (type.getParameters().isEmpty()) {
             return getRawName(type);

--- a/src/test/java/com/mysema/codegen/JavaWriterTest.java
+++ b/src/test/java/com/mysema/codegen/JavaWriterTest.java
@@ -224,6 +224,11 @@ public class JavaWriterTest {
     }
 
     @Test
+    public void ClassConstants() {
+        assertEquals("SomeClass.class", writer.getClassConstant("SomeClass"));
+    }
+
+    @Test
     public void Fields() throws IOException {
         writer.beginClass(testType);
         // private
@@ -330,5 +335,4 @@ public class JavaWriterTest {
 
         match("/testSuppressWarnings", w.toString());
     }
-
 }

--- a/src/test/java/com/mysema/codegen/ScalaWriterTest.java
+++ b/src/test/java/com/mysema/codegen/ScalaWriterTest.java
@@ -367,6 +367,11 @@ public class ScalaWriterTest {
     }
 
     @Test
+    public void ClassConstants() {
+        assertEquals("classOf[SomeClass]", writer.getClassConstant("SomeClass"));
+    }
+
+    @Test
     public void Primitive() throws IOException {
         writer.beginClass(testType);
 
@@ -381,7 +386,7 @@ public class ScalaWriterTest {
     }
 
     @Test
-    public void Primive_Types() throws IOException {
+    public void Primitive_Types() throws IOException {
         writer.field(Types.BOOLEAN_P, "field");
         writer.field(Types.BYTE_P, "field");
         writer.field(Types.CHAR, "field");
@@ -417,5 +422,4 @@ public class ScalaWriterTest {
         assertTrue(w.toString().contains("`class`: JavaWriterTest"));
         assertTrue(w.toString().contains("`var`(): JavaWriterTest"));
     }
-
 }


### PR DESCRIPTION
To be used in querydsl-codegen shortly.
