### PR TITLE
Synchronize class generation to prevent corruption

### DIFF
--- a/src/main/java/com/mysema/codegen/AbstractEvaluatorFactory.java
+++ b/src/main/java/com/mysema/codegen/AbstractEvaluatorFactory.java
@@ -114,7 +114,7 @@ public abstract class AbstractEvaluatorFactory implements EvaluatorFactory {
      */
     @SuppressWarnings("unchecked")
     @Override
-    public <T> Evaluator<T> createEvaluator(String source, ClassType projection, String[] names,
+    public synchronized <T> Evaluator<T> createEvaluator(String source, ClassType projection, String[] names,
             Type[] types, Class<?>[] classes, Map<String, Object> constants) {
         try {
             final String id = toId(source, projection.getJavaClass(), types, constants.values());


### PR DESCRIPTION
``` java
java.lang.ClassFormatError: Extra bytes at the end of class file Q_01686498692_02056817302_032091036
 at java.lang.ClassLoader.defineClass1(Native Method)
 at java.lang.ClassLoader.defineClass(ClassLoader.java:800)
 at java.lang.ClassLoader.defineClass(ClassLoader.java:643)
 at com.mysema.codegen.MemClassLoader.findClass(MemClassLoader.java:60)
 at java.lang.ClassLoader.loadClass(ClassLoader.java:425)
 at java.lang.ClassLoader.loadClass(ClassLoader.java:358)
 at com.mysema.codegen.AbstractEvaluatorFactory.createEvaluator(AbstractEvaluatorFactory.java:130)

 at com.mysema.codegen.AbstractEvaluatorFactory.createEvaluator(AbstractEvaluatorFactory.java:94)
 at com.mysema.query.collections.DefaultEvaluatorFactory.create(DefaultEvaluatorFactory.java:125)
 at com.mysema.query.collections.DefaultQueryEngine.project(DefaultQueryEngine.java:234)
 at com.mysema.query.collections.DefaultQueryEngine.evaluateSingleSource(DefaultQueryEngine.java:192)
 at com.mysema.query.collections.DefaultQueryEngine.list(DefaultQueryEngine.java:91)
 at com.mysema.query.collections.AbstractCollQuery.list(AbstractCollQuery.java:202)
```

can occur when multiple threads attempt to generate classes simultaneously.

Link to original issue: https://groups.google.com/forum/#!topic/querydsl/ud4ow-siCn8
