### PR TITLE
Traverse superclasses for a visible class

### DIFF
--- a/src/main/java/com/mysema/codegen/support/ClassUtils.java
+++ b/src/main/java/com/mysema/codegen/support/ClassUtils.java
@@ -13,11 +13,8 @@
  */
 package com.mysema.codegen.support;
 
-import java.util.Collection;
-import java.util.Collections;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
+import java.lang.reflect.Modifier;
+import java.util.*;
 
 /**
  * @author tiwe
@@ -91,6 +88,8 @@ public final class ClassUtils {
             if (zuper != null && !Object.class.equals(zuper)) {
                 return zuper;
             }
+        } else if (!Modifier.isPublic(clazz.getModifiers())) {
+            return normalize(clazz.getSuperclass());
         }
         return clazz;
     }

--- a/src/test/java/com/mysema/codegen/support/ClassUtilsTest.java
+++ b/src/test/java/com/mysema/codegen/support/ClassUtilsTest.java
@@ -7,16 +7,12 @@ package com.mysema.codegen.support;
 
 import static org.junit.Assert.assertEquals;
 
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Locale;
-import java.util.Map;
-import java.util.Set;
+import java.util.*;
 
 import org.junit.Test;
+
+import com.google.common.base.Optional;
+import com.google.common.collect.Ordering;
 
 public class ClassUtilsTest {
 
@@ -52,4 +48,15 @@ public class ClassUtilsTest {
 //        assertEquals(Collection.class, ClassUtils.normalize(Bag.class));
     }
 
+    @Test
+    public void Normalize_Accessibility() {
+        //com.google.common.base.Absent is not public, cannot be accessed from outside package
+        assertEquals(Optional.class, ClassUtils.normalize(Optional.absent().getClass()));
+        //com.google.common.collect.AllEqualOrdering is not public, cannot be accessed from outside package
+        assertEquals(Ordering.class, ClassUtils.normalize(Ordering.allEqual().getClass()));
+
+        //TODO interface normalization support? How to know which one?
+        //com.google.common.base.Functions.ToStringFunction is not public, cannot be accessed from outside package
+        //assertEquals(Function.class, ClassUtils.normalize(Functions.toStringFunction().getClass()));
+    }
 }


### PR DESCRIPTION
`progress` label needed.

I haven't yet found a class that is *not* a descendant of `Map`, `List` or `Set` and has at least two non-visible parents.
@timowest There may be a better way of going about this, it is maybe also solvable in querydsl-core in the creation of a `ConstantImpl`?