### PR TITLE
Fix syntax error in method with return type in ScalaWriter

### DIFF
--- a/src/main/java/com/mysema/codegen/ScalaWriter.java
+++ b/src/main/java/com/mysema/codegen/ScalaWriter.java
@@ -295,7 +295,7 @@ public class ScalaWriter extends AbstractCodeWriter<ScalaWriter> {
             beginLine(modifiers, escape(methodName)).params(args).append(" {").nl();
         } else {
             beginLine(modifiers, escape(methodName)).params(args)
-                    .append(": ").append(getGenericName(true, returnType)).append(" {").nl();
+                    .append(": ").append(getGenericName(true, returnType)).append(" = {").nl();
         }
 
         return goIn();


### PR DESCRIPTION
Previous code would generate a method like :

```scala
def one(): Integer {
  1
}
```
 which is incorrect. The correct syntax is : 


```scala
def one(): Integer = {
  1
}
```

I'm using Scala 2.11. I don't know if it's a new syntax for this version or not, but I'm pretty sure the version with "=" is correct in older versions.
