### PR TITLE
Add method beginOverridePublicMethod for ScalaWriter

### DIFF
--- a/src/main/java/com/mysema/codegen/ScalaWriter.java
+++ b/src/main/java/com/mysema/codegen/ScalaWriter.java
@@ -44,6 +44,8 @@ public class ScalaWriter extends AbstractCodeWriter<ScalaWriter> {
 
     private static final String DEF = "def ";
 
+    private static final String OVERRIDE_DEF = "override " + DEF;
+
     private static final String EXTENDS = " extends ";
 
     private static final String WITH = " with ";
@@ -311,6 +313,17 @@ public class ScalaWriter extends AbstractCodeWriter<ScalaWriter> {
     public ScalaWriter beginPublicMethod(Type returnType, String methodName, Parameter... args)
             throws IOException {
         return beginMethod(DEF, returnType, methodName, args);
+    }
+
+    public <T> ScalaWriter beginOverridePublicMethod(Type returnType, String methodName,
+                                                     Collection<T> parameters, Function<T, Parameter> transformer)
+            throws IOException {
+        return beginMethod(OVERRIDE_DEF, returnType, methodName, transform(parameters, transformer));
+    }
+
+    public ScalaWriter beginOverridePublicMethod(Type returnType, String methodName, Parameter... args)
+            throws IOException {
+        return beginMethod(OVERRIDE_DEF, returnType, methodName, args);
     }
 
     @Override


### PR DESCRIPTION
Add ability to create override def methods.

This is required for querydsl if the BeanSerializer used is a custom class that wants to generate equals and hashCode methods on Beans. Such methods are required to have the override modifier.