### PR TITLE
Fix exception when using querydsl in eclipselink as apt processor

### DIFF
--- a/src/main/java/com/mysema/codegen/model/SimpleType.java
+++ b/src/main/java/com/mysema/codegen/model/SimpleType.java
@@ -72,7 +72,7 @@ public class SimpleType implements Type {
         this.fullName = fullName;
         this.packageName = packageName;
         this.simpleName = simpleName;
-        if (packageName.length() > 0) {
+        if (packageName.length() > 0 && fullName.length() > packageName.length()) {
             this.localName = fullName.substring(packageName.length() + 1);
         } else {
             this.localName = fullName;
@@ -126,7 +126,8 @@ public class SimpleType implements Type {
         }
     }
 
-    public TypeCategory getCategory() {
+    @Override
+	public TypeCategory getCategory() {
         return category;
     }
 


### PR DESCRIPTION
The following exception sometimes occurs in eclipse when creating query dsl classes. For some reason eclipse passes a "fullName" that does not include the package to the processor. This patch fixes the following exception:

java.lang.Exception: java.lang.StringIndexOutOfBoundsException: String
index out of range: -39
	at
org.eclipse.jdt.internal.compiler.apt.dispatch.RoundDispatcher.handleProcessor(RoundDispatcher.java:169)
	at
org.eclipse.jdt.internal.compiler.apt.dispatch.RoundDispatcher.round(RoundDispatcher.java:121)
	at
org.eclipse.jdt.internal.compiler.apt.dispatch.BaseAnnotationProcessorManager.processAnnotations(BaseAnnotationProcessorManager.java:159)
	at
org.eclipse.jdt.internal.apt.pluggable.core.dispatch.IdeAnnotationProcessorManager.processAnnotations(IdeAnnotationProcessorManager.java:135)
	at
org.eclipse.jdt.internal.compiler.Compiler.processAnnotations(Compiler.java:927)
	at
org.eclipse.jdt.internal.compiler.Compiler.compile(Compiler.java:447)
	at
org.eclipse.jdt.internal.compiler.Compiler.compile(Compiler.java:427)
	at
org.eclipse.jdt.internal.core.builder.AbstractImageBuilder.compile(AbstractImageBuilder.java:392)
	at
org.eclipse.jdt.internal.core.builder.BatchImageBuilder.compile(BatchImageBuilder.java:192)
	at
org.eclipse.jdt.internal.core.builder.AbstractImageBuilder.compile(AbstractImageBuilder.java:329)
	at
org.eclipse.jdt.internal.core.builder.BatchImageBuilder.build(BatchImageBuilder.java:63)
	at
org.eclipse.jdt.internal.core.builder.JavaBuilder.buildAll(JavaBuilder.java:256)
	at
org.eclipse.jdt.internal.core.builder.JavaBuilder.build(JavaBuilder.java:175)
	at
org.eclipse.core.internal.events.BuildManager$2.run(BuildManager.java:735)
	at org.eclipse.core.runtime.SafeRunner.run(SafeRunner.java:42)
	at
org.eclipse.core.internal.events.BuildManager.basicBuild(BuildManager.java:206)
	at
org.eclipse.core.internal.events.BuildManager.basicBuild(BuildManager.java:246)
	at
org.eclipse.core.internal.events.BuildManager$1.run(BuildManager.java:301)
	at org.eclipse.core.runtime.SafeRunner.run(SafeRunner.java:42)
	at
org.eclipse.core.internal.events.BuildManager.basicBuild(BuildManager.java:304)
	at
org.eclipse.core.internal.events.BuildManager.basicBuildLoop(BuildManager.java:360)
	at
org.eclipse.core.internal.events.BuildManager.build(BuildManager.java:383)
	at
org.eclipse.core.internal.resources.Workspace.buildInternal(Workspace.java:487)
	at
org.eclipse.core.internal.resources.Workspace.build(Workspace.java:399)
	at
org.eclipse.oomph.setup.internal.core.SetupTaskPerformer$5.run(SetupTaskPerformer.java:3369)
	at org.eclipse.core.internal.jobs.Worker.run(Worker.java:56)
Caused by: java.lang.StringIndexOutOfBoundsException: String index out
of range: -39
	at java.lang.String.substring(String.java:1931)
	at com.mysema.codegen.model.SimpleType.<init>(SimpleType.java:76)
	at com.mysema.codegen.model.SimpleType.<init>(SimpleType.java:93)
	at
com.querydsl.apt.ExtendedTypeFactory.createType(ExtendedTypeFactory.java:289)
	at
com.querydsl.apt.ExtendedTypeFactory.createClassType(ExtendedTypeFactory.java:384)
	at
com.querydsl.apt.ExtendedTypeFactory.access$100(ExtendedTypeFactory.java:37)
	at
com.querydsl.apt.ExtendedTypeFactory$1.visitDeclared(ExtendedTypeFactory.java:113)
	at
com.querydsl.apt.ExtendedTypeFactory$1.visitError(ExtendedTypeFactory.java:124)
	at
com.querydsl.apt.ExtendedTypeFactory$1.visitError(ExtendedTypeFactory.java:59)
	at
org.eclipse.jdt.internal.compiler.apt.model.ErrorTypeImpl.accept(ErrorTypeImpl.java:88)
	at
javax.lang.model.util.AbstractTypeVisitor6.visit(AbstractTypeVisitor6.java:92)
	at
com.querydsl.apt.ExtendedTypeFactory.createType(ExtendedTypeFactory.java:311)
	at
com.querydsl.apt.ExtendedTypeFactory.getType(ExtendedTypeFactory.java:304)
	at
com.querydsl.apt.TypeElementHandler.getType(TypeElementHandler.java:181)
	at
com.querydsl.apt.TypeElementHandler.transformParams(TypeElementHandler.java:204)
	at
com.querydsl.apt.AbstractQuerydslProcessor.processDelegateMethods(AbstractQuerydslProcessor.java:437)
	at
com.querydsl.apt.AbstractQuerydslProcessor.collectElements(AbstractQuerydslProcessor.java:197)
	at
com.querydsl.apt.AbstractQuerydslProcessor.processAnnotations(AbstractQuerydslProcessor.java:102)
	at
com.querydsl.apt.AbstractQuerydslProcessor.process(AbstractQuerydslProcessor.java:89)
	at
org.eclipse.jdt.internal.compiler.apt.dispatch.RoundDispatcher.handleProcessor(RoundDispatcher.java:139)
	... 25 more