### PR TITLE
Update COMPARABLE TypeCategory so that java.util.UUID instances are deemed to be comparable

### DIFF
--- a/src/main/java/com/mysema/codegen/model/TypeCategory.java
+++ b/src/main/java/com/mysema/codegen/model/TypeCategory.java
@@ -50,7 +50,7 @@ public enum TypeCategory {
     /**
      *
      */
-    COMPARABLE(SIMPLE),
+    COMPARABLE(SIMPLE, java.util.UUID.class.getName()),
     /**
      *
      */

--- a/src/main/java/com/mysema/codegen/model/TypeCategory.java
+++ b/src/main/java/com/mysema/codegen/model/TypeCategory.java
@@ -50,7 +50,7 @@ public enum TypeCategory {
     /**
      *
      */
-    COMPARABLE(SIMPLE, java.util.UUID.class.getName()),
+    COMPARABLE(SIMPLE),
     /**
      *
      */
@@ -93,7 +93,12 @@ public enum TypeCategory {
      *
      */
     TIME(COMPARABLE, java.sql.Time.class.getName(), "org.joda.time.LocalTime",
-            "java.time.LocalTime", "java.time.OffsetTime");
+            "java.time.LocalTime", "java.time.OffsetTime"),
+
+    /**
+     *
+     */
+    UUID(COMPARABLE, java.util.UUID.class.getName());
 
     private final TypeCategory superType;
 


### PR DESCRIPTION
The change in this PR solves querydsl issue 2220 (https://github.com/querydsl/querydsl/issues/2220, which is documented in more detail here: https://groups.google.com/forum/m/#!msg/querydsl/iS0fNn16EO4/Hj6JJ3ACAgAJ).