### PR TITLE
Code generation support for application running in a fat JAR

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1,126 +1,110 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd" xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd" xmlns="http://maven.apache.org/POM/4.0.0">
 
-  <modelVersion>4.0.0</modelVersion>
-  <groupId>com.mysema.codegen</groupId>
-  <artifactId>codegen</artifactId>
-  <version>0.6.9.BUILD-SNAPSHOT</version>
-  <name>Codegen</name>
-  <description>Code generation and compilation for Java</description>
-  
-  <parent>
-    <groupId>com.mysema.home</groupId>
-    <artifactId>mysema-source</artifactId>
-    <version>0.3.1</version>
-  </parent>
-  
-  <packaging>jar</packaging>
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>com.mysema.codegen</groupId>
+    <artifactId>codegen</artifactId>
+    <version>0.6.9.BUILD-SNAPSHOT</version>
+    <name>Codegen</name>
+    <description>Code generation and compilation for Java</description>
 
-  <inceptionYear>2010</inceptionYear>
-  
-  <licenses>
-    <license>
-      <name>Apache License, Version 2.0</name>
-      <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
-    </license>
-  </licenses>
-  
-  <scm>
-    <connection>scm:git:git@github.com:querydsl/codegen.git</connection>
-    <url>git@github.com:querydsl/codegen.git</url>
-  </scm>    
-  
-  <properties>
-    <commons.collections.version>4.01</commons.collections.version>
-    <commons.lang.version>3.0.1</commons.lang.version>
-    <guava.version>11.0.2</guava.version>
-    <ecj.version>4.3.1</ecj.version>
-  </properties>
-  
-  <dependencies>
-    <dependency>
-      <groupId>com.google.guava</groupId>
-      <artifactId>guava</artifactId>
-      <version>18.0</version>
-    </dependency>
-    
-    <dependency>
-      <groupId>org.eclipse.jdt.core.compiler</groupId>
-      <artifactId>ecj</artifactId>
-      <version>${ecj.version}</version>
-    </dependency>    
-         
-    <!-- test -->
-    <dependency>
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
-      <version>4.8.1</version>
-      <scope>test</scope>
-      <exclusions>
-        <exclusion>
-          <groupId>javax.servlet</groupId>
-          <artifactId>servlet-api</artifactId>
-        </exclusion>
-      </exclusions>
-    </dependency>
-    <dependency>
-      <groupId>javax.validation</groupId>
-      <artifactId>validation-api</artifactId>
-      <version>1.0.CR3</version>
-      <scope>test</scope>
-    </dependency>
-    
-            
-  </dependencies>
-  
-  <build>
-    <plugins>
-        <plugin>
-          <groupId>org.apache.maven.plugins</groupId>
-          <artifactId>maven-jar-plugin</artifactId>
-          <configuration>
-            <useDefaultManifestFile>true</useDefaultManifestFile>
-          </configuration>
-        </plugin>
-        <plugin>
-	      <groupId>com.springsource.bundlor</groupId>
-	      <artifactId>com.springsource.bundlor.maven</artifactId>
-	      <version>1.0.0.RELEASE</version>
-	      <executions>
-	        <execution>
-	          <id>bundlor</id>
-	          <goals>
-	            <goal>bundlor</goal>
-	          </goals>
-	        </execution>
-	      </executions>
-	      <configuration>
-	        <failOnWarnings>true</failOnWarnings> 
-	      </configuration>
-      	</plugin>    
-    </plugins>
-  </build>
-  
-<!--   
-  <repositories>
-    <repository>
-	  <id>jboss</id>
-	  <url>http://repository.jboss.org/maven2</url>
-      <releases>
-        <enabled>true</enabled>
-      </releases>
-      <snapshots>
-        <enabled>false</enabled>
-      </snapshots>
-	</repository>
-  </repositories>  
--->
-  
-  <pluginRepositories>
-    <pluginRepository>
-      <id>com.springsource.repository.bundles.release</id>
-      <url>http://repository.springsource.com/maven/bundles/release</url>
-    </pluginRepository>
-  </pluginRepositories>
+    <parent>
+        <groupId>com.mysema.home</groupId>
+        <artifactId>mysema-source</artifactId>
+        <version>0.3.1</version>
+    </parent>
+
+    <packaging>jar</packaging>
+
+    <inceptionYear>2010</inceptionYear>
+
+    <licenses>
+        <license>
+            <name>Apache License, Version 2.0</name>
+            <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
+        </license>
+    </licenses>
+
+    <scm>
+        <connection>scm:git:git@github.com:querydsl/codegen.git</connection>
+        <url>git@github.com:querydsl/codegen.git</url>
+    </scm>
+
+    <properties>
+        <maven.compiler.source>1.6</maven.compiler.source>
+        <maven.compiler.target>1.6</maven.compiler.target>
+        <commons.collections.version>4.01</commons.collections.version>
+        <commons.lang.version>3.0.1</commons.lang.version>
+        <guava.version>11.0.2</guava.version>
+        <ecj.version>4.3.1</ecj.version>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>com.google.guava</groupId>
+            <artifactId>guava</artifactId>
+            <version>18.0</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.eclipse.jdt.core.compiler</groupId>
+            <artifactId>ecj</artifactId>
+            <version>${ecj.version}</version>
+        </dependency>
+
+        <!-- test -->
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <version>4.8.1</version>
+            <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>javax.servlet</groupId>
+                    <artifactId>servlet-api</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>javax.validation</groupId>
+            <artifactId>validation-api</artifactId>
+            <version>1.0.CR3</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+                <version>3.1.0</version>
+            </plugin>
+            <plugin>
+                <groupId>com.springsource.bundlor</groupId>
+                <artifactId>com.springsource.bundlor.maven</artifactId>
+                <version>1.0.0.RELEASE</version>
+                <executions>
+                    <execution>
+                        <id>bundlor</id>
+                        <goals>
+                            <goal>bundlor</goal>
+                        </goals>
+                    </execution>
+                </executions>
+                <configuration>
+                    <failOnWarnings>true</failOnWarnings>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
+    <pluginRepositories>
+        <pluginRepository>
+            <id>com.springsource.repository.bundles.release</id>
+            <url>http://repository.springsource.com/maven/bundles/release</url>
+        </pluginRepository>
+    </pluginRepositories>
 
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -57,19 +57,19 @@
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
-            <version>4.8.1</version>
+            <version>4.12</version>
             <scope>test</scope>
-            <exclusions>
-                <exclusion>
-                    <groupId>javax.servlet</groupId>
-                    <artifactId>servlet-api</artifactId>
-                </exclusion>
-            </exclusions>
         </dependency>
         <dependency>
             <groupId>javax.validation</groupId>
             <artifactId>validation-api</artifactId>
             <version>1.0.CR3</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>pl.pragmatists</groupId>
+            <artifactId>JUnitParams</artifactId>
+            <version>1.1.1</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/src/main/java/com/mysema/codegen/CompiledJavaFileObject.java
+++ b/src/main/java/com/mysema/codegen/CompiledJavaFileObject.java
@@ -1,0 +1,125 @@
+/*
+ * Copyright 2018, The Querydsl Team (http://www.querydsl.com/team)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.mysema.codegen;
+
+import java.net.URI;
+import java.io.*;
+import javax.tools.JavaFileObject;
+import javax.lang.model.element.NestingKind;
+import javax.lang.model.element.Modifier;
+
+/**
+ * CompiledJavaFileObject defines a Java class file object that can be in a folder or in a JAR
+ *
+ * @author <a href="mailto:matteo.gallo@britebill.com">Matteo Gallo</a>
+ */
+class CompiledJavaFileObject implements JavaFileObject {
+
+    private final String binaryName;
+
+    private final URI uri;
+
+    private final String name;
+
+    public CompiledJavaFileObject(String binaryName, URI uri) {
+        this.uri = uri;
+        this.binaryName = binaryName;
+        // for FS based URI the path is not null, for JAR URI the scheme specific part is not null
+        name = uri.getPath() == null ? uri.getSchemeSpecificPart() : uri.getPath();
+    }
+
+    @Override
+    public URI toUri() {
+        return uri;
+    }
+
+    @Override
+    public InputStream openInputStream() throws IOException {
+        // easy way to handle any URI!
+        return uri.toURL().openStream();
+    }
+
+    @Override
+    public OutputStream openOutputStream() throws IOException {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public String getName() {
+        return name;
+    }
+
+    @Override
+    public Reader openReader(boolean ignoreEncodingErrors) throws IOException {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public CharSequence getCharContent(boolean ignoreEncodingErrors) throws IOException {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Writer openWriter() throws IOException {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public long getLastModified() {
+        return 0;
+    }
+
+    @Override
+    public boolean delete() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Kind getKind() {
+        return Kind.CLASS;
+    }
+
+    @Override
+    // copied from SimpleJavaFileObject
+    public boolean isNameCompatible(String simpleName, Kind kind) {
+        String baseName = simpleName + kind.extension;
+        return kind.equals(getKind())
+                && (baseName.equals(getName())
+                || getName().endsWith("/" + baseName));
+    }
+
+    @Override
+    public NestingKind getNestingKind() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Modifier getAccessLevel() {
+        throw new UnsupportedOperationException();
+    }
+
+    public String binaryName() {
+        return binaryName;
+    }
+
+
+    @Override
+    public String toString() {
+        return "CustomJavaFileObject{" +
+                "uri=" + uri +
+                '}';
+    }
+}

--- a/src/main/java/com/mysema/codegen/CompiledJavaFileObject.java
+++ b/src/main/java/com/mysema/codegen/CompiledJavaFileObject.java
@@ -22,9 +22,12 @@ import javax.lang.model.element.NestingKind;
 import javax.lang.model.element.Modifier;
 
 /**
- * CompiledJavaFileObject defines a Java class file object that can be in a folder or in a JAR
+ * CompiledJavaFileObject defines a Java class file object that can be in a folder or in a JAR.
  *
- * @author <a href="mailto:matteo.gallo@britebill.com">Matteo Gallo</a>
+ * NOTE: This is a derivative work from an article of atamur.
+ *  Original article can be found here: http://atamur.blogspot.com/2009/10/using-built-in-javacompiler-with-custom.html
+ *
+ * @author matteo-gallo-bb
  */
 class CompiledJavaFileObject implements JavaFileObject {
 
@@ -53,7 +56,7 @@ class CompiledJavaFileObject implements JavaFileObject {
     }
 
     @Override
-    public OutputStream openOutputStream() throws IOException {
+    public OutputStream openOutputStream() {
         throw new UnsupportedOperationException();
     }
 
@@ -63,17 +66,17 @@ class CompiledJavaFileObject implements JavaFileObject {
     }
 
     @Override
-    public Reader openReader(boolean ignoreEncodingErrors) throws IOException {
+    public Reader openReader(boolean ignoreEncodingErrors) {
         throw new UnsupportedOperationException();
     }
 
     @Override
-    public CharSequence getCharContent(boolean ignoreEncodingErrors) throws IOException {
+    public CharSequence getCharContent(boolean ignoreEncodingErrors) {
         throw new UnsupportedOperationException();
     }
 
     @Override
-    public Writer openWriter() throws IOException {
+    public Writer openWriter() {
         throw new UnsupportedOperationException();
     }
 

--- a/src/main/java/com/mysema/codegen/JavaClassesFinder.java
+++ b/src/main/java/com/mysema/codegen/JavaClassesFinder.java
@@ -1,0 +1,120 @@
+/*
+ * Copyright 2018, The Querydsl Team (http://www.querydsl.com/team)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.mysema.codegen;
+
+import javax.tools.JavaFileObject;
+import java.io.File;
+import java.io.IOException;
+import java.net.JarURLConnection;
+import java.net.URI;
+import java.net.URL;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Enumeration;
+import java.util.List;
+import java.util.jar.JarEntry;
+
+import static javax.tools.JavaFileObject.Kind.CLASS;
+
+/**
+ * JavaClassesFinder finds Java file classes using the specified Classloader
+ *
+ * @author <a href="mailto:matteo.gallo@britebill.com">Matteo Gallo</a>
+ */
+class JavaClassesFinder {
+
+    private ClassLoader classLoader;
+
+    public JavaClassesFinder(ClassLoader classLoader) {
+        this.classLoader = classLoader;
+    }
+
+    /**
+     * List all the Java file classes that are present in the specified package.
+     *
+     * @param packageName the package name where to
+     * @return a list of Java file classes
+     * @throws IOException
+     */
+    public List<JavaFileObject> listAll(String packageName) throws IOException {
+        String javaPackageName = packageName.replaceAll("\\.", "/");
+
+        List<JavaFileObject> result = new ArrayList<JavaFileObject>();
+
+        Enumeration<URL> urlEnumeration = classLoader.getResources(javaPackageName);
+        while (urlEnumeration.hasMoreElements()) {
+            // one URL for each jar on the classpath that has the given package
+            URL packageFolderURL = urlEnumeration.nextElement();
+            result.addAll(listUnder(packageName, packageFolderURL));
+        }
+
+        return result;
+    }
+
+    private Collection<JavaFileObject> listUnder(String packageName, URL packageFolderURL) {
+        File directory = new File(packageFolderURL.getFile());
+        if (directory.isDirectory()) {
+            // browse local .class files - useful for local execution
+            return processDir(packageName, directory);
+        } else {
+            // browse a jar file
+            return processJar(packageFolderURL);
+        }
+    }
+
+    private List<JavaFileObject> processJar(URL packageFolderURL) {
+        List<JavaFileObject> result = new ArrayList<JavaFileObject>();
+        try {
+            JarURLConnection jarConn = (JarURLConnection) packageFolderURL.openConnection();
+            String jarUri = jarConn.getJarFileURL().toString();
+            String rootEntryName = jarConn.getEntryName();
+            int rootEnd = rootEntryName.length() + 1;
+
+            Enumeration<JarEntry> entryEnum = jarConn.getJarFile().entries();
+            while (entryEnum.hasMoreElements()) {
+                JarEntry jarEntry = entryEnum.nextElement();
+                String name = jarEntry.getName();
+                if (name.startsWith(rootEntryName) && name.indexOf('/', rootEnd) == -1 && name.endsWith(CLASS.extension)) {
+                    URI uri = URI.create(jarUri + "!/" + name);
+                    String binaryName = name.replaceAll("/", ".");
+                    binaryName = binaryName.replaceAll(CLASS.extension + "$", "");
+
+                    result.add(new CompiledJavaFileObject(binaryName, uri));
+                }
+            }
+        } catch (Exception e) {
+            throw new CodegenException("Wasn't able to open " + packageFolderURL + " as a jar file", e);
+        }
+        return result;
+    }
+
+    private List<JavaFileObject> processDir(String packageName, File directory) {
+        List<JavaFileObject> result = new ArrayList<JavaFileObject>();
+
+        File[] childFiles = directory.listFiles();
+        for (File childFile : childFiles) {
+            // We only want the .class files
+            if (childFile.isFile() && childFile.getName().endsWith(CLASS.extension)) {
+                String binaryName = packageName + "." + childFile.getName();
+                binaryName = binaryName.replaceAll(CLASS.extension + "$", "");
+
+                result.add(new CompiledJavaFileObject(binaryName, childFile.toURI()));
+            }
+        }
+
+        return result;
+    }
+}

--- a/src/main/java/com/mysema/codegen/JavaClassesFinder.java
+++ b/src/main/java/com/mysema/codegen/JavaClassesFinder.java
@@ -83,7 +83,7 @@ class JavaClassesFinder {
         try {
             JarURLConnection jarConn = (JarURLConnection) packageFolderURL.openConnection();
             String jarUri = jarConn.getJarFileURL().toString();
-            String rootEntryName = jarConn.getEntryName();
+            String rootEntryName = jarConn.getEntryName() != null ? jarConn.getEntryName() : "";
             int rootEnd = rootEntryName.length() + 1;
 
             Enumeration<JarEntry> entryEnum = jarConn.getJarFile().entries();

--- a/src/main/java/com/mysema/codegen/JavaClassesFinder.java
+++ b/src/main/java/com/mysema/codegen/JavaClassesFinder.java
@@ -32,20 +32,23 @@ import static javax.tools.JavaFileObject.Kind.CLASS;
 /**
  * JavaClassesFinder finds Java file classes using the specified Classloader
  *
- * @author <a href="mailto:matteo.gallo@britebill.com">Matteo Gallo</a>
+ * NOTE: This is a derivative work from an article of atamur.
+ *  Original article can be found here: http://atamur.blogspot.com/2009/10/using-built-in-javacompiler-with-custom.html
+ *
+ * @author matteo-gallo-bb
  */
 class JavaClassesFinder {
 
     private ClassLoader classLoader;
 
-    public JavaClassesFinder(ClassLoader classLoader) {
+    JavaClassesFinder(ClassLoader classLoader) {
         this.classLoader = classLoader;
     }
 
     /**
      * List all the Java file classes that are present in the specified package.
      *
-     * @param packageName the package name where to
+     * @param packageName
      * @return a list of Java file classes
      * @throws IOException
      */

--- a/src/main/java/com/mysema/codegen/SimpleCompiler.java
+++ b/src/main/java/com/mysema/codegen/SimpleCompiler.java
@@ -1,10 +1,12 @@
 /*
- * Copyright 2010, Mysema Ltd
- * 
+ * Copyright 2018, The Querydsl Team (http://www.querydsl.com/team)
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -14,10 +16,7 @@
 package com.mysema.codegen;
 
 import java.io.*;
-import java.net.JarURLConnection;
-import java.net.URL;
-import java.net.URLClassLoader;
-import java.net.URLDecoder;
+import java.net.*;
 import java.nio.charset.Charset;
 import java.util.ArrayList;
 import java.util.List;
@@ -70,16 +69,15 @@ public class SimpleCompiler implements JavaCompiler {
                 while (c instanceof URLClassLoader) {
                     for (URL url : ((URLClassLoader)c).getURLs()) {
                         if (url.openConnection() instanceof JarURLConnection) {
-                            // extract the file URL from the jar URL
-                            JarURLConnection connection = (JarURLConnection) url.openConnection();
-                            url = connection.getJarFileURL();
+                            paths.add(url.toString());
+                        } else {
+                            String decodedPath = URLDecoder.decode(url.getPath(), "UTF-8");
+                            paths.add(new File(decodedPath).getAbsolutePath());
                         }
-                        String decodedPath = URLDecoder.decode(url.getPath(), "UTF-8");
-                        paths.add(new File(decodedPath).getAbsolutePath());
                     }
                     c = c.getParent();
                 }
-            }            
+            }
             return pathJoiner.join(paths);
         } catch (UnsupportedEncodingException e) {
             throw new CodegenException(e);

--- a/src/main/java/com/mysema/codegen/SimpleCompiler.java
+++ b/src/main/java/com/mysema/codegen/SimpleCompiler.java
@@ -14,6 +14,7 @@
 package com.mysema.codegen;
 
 import java.io.*;
+import java.net.JarURLConnection;
 import java.net.URL;
 import java.net.URLClassLoader;
 import java.net.URLDecoder;
@@ -68,6 +69,11 @@ public class SimpleCompiler implements JavaCompiler {
                 ClassLoader c = cl;
                 while (c instanceof URLClassLoader) {
                     for (URL url : ((URLClassLoader)c).getURLs()) {
+                        if (url.openConnection() instanceof JarURLConnection) {
+                            // extract the file URL from the jar URL
+                            JarURLConnection connection = (JarURLConnection) url.openConnection();
+                            url = connection.getJarFileURL();
+                        }
                         String decodedPath = URLDecoder.decode(url.getPath(), "UTF-8");
                         paths.add(new File(decodedPath).getAbsolutePath());
                     }

--- a/src/test/java/com/mysema/codegen/JavaClassesFinderTest.java
+++ b/src/test/java/com/mysema/codegen/JavaClassesFinderTest.java
@@ -1,0 +1,133 @@
+/*
+ * Copyright 2018, The Querydsl Team (http://www.querydsl.com/team)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.mysema.codegen;
+
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+import javax.tools.JavaFileObject;
+import java.io.*;
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.util.Enumeration;
+import java.util.List;
+import java.util.Vector;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipOutputStream;
+
+import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
+
+/**
+ * JavaClassesFinder unit test
+ *
+ * @author matteo-gallo-bb
+ */
+public class JavaClassesFinderTest {
+
+    private File tmpBaseDir;
+
+    @Rule
+    public TemporaryFolder temporaryFolder = new TemporaryFolder();
+
+    @Before
+    public void setUp() {
+        tmpBaseDir = temporaryFolder.newFolder("javaClassesFinderTest");
+    }
+
+    @Test
+    public void listAll() throws IOException {
+        // given
+        File bootJarFile = createSampleJarFile();
+        String bootJarFilePath = bootJarFile.getAbsolutePath();
+        JavaClassesFinder finder = new JavaClassesFinder(new ClassLoaderMock(bootJarFilePath));
+
+        // when
+        List<JavaFileObject> javaFileObjectList = finder.listAll("com.mysema.codegen.model");
+
+        // then
+        assertNotNull(javaFileObjectList);
+        assertEquals(1, javaFileObjectList.size());
+        assertTrue(javaFileObjectList.get(0) instanceof CompiledJavaFileObject);
+        CompiledJavaFileObject javaFileObject = (CompiledJavaFileObject) javaFileObjectList.get(0);
+        assertEquals("com.mysema.codegen.model.ClassType", javaFileObject.binaryName());
+        assertEquals(bootJarFilePath + "!/com/mysema/codegen/model/ClassType.class", javaFileObject.getName());
+    }
+
+    private File createSampleJarFile() throws IOException {
+        File classTypeFile = createAndWriteTmpClassFile("ClassType.class");
+
+        //create a boot jar file
+        File bootJar = new File(tmpBaseDir,"exampleBoot.jar");
+        FileOutputStream outputStream = new FileOutputStream(bootJar);
+        ZipOutputStream sampleJar = new ZipOutputStream(outputStream);
+
+        // adding ClassType file and folders to boot jar file
+        sampleJar.putNextEntry(new ZipEntry("com/"));
+        sampleJar.putNextEntry(new ZipEntry("com/mysema/"));
+        sampleJar.putNextEntry(new ZipEntry("com/mysema/codegen/"));
+        sampleJar.putNextEntry(new ZipEntry("com/mysema/codegen/model/"));
+        ZipEntry zeClassType = new ZipEntry("com/mysema/codegen/model/" + classTypeFile.getName());
+        sampleJar.putNextEntry(zeClassType);
+
+        // writing ClassType file in boot jar file
+        FileInputStream inputStream = new FileInputStream(classTypeFile);
+        byte[] buffer = new byte[1024];
+        for (int len; (len = inputStream.read(buffer)) > 0;) {
+            sampleJar.write(buffer, 0, len);
+        }
+        inputStream.close();
+        sampleJar.closeEntry();
+
+        sampleJar.close();
+
+        return bootJar;
+    }
+
+    private File createAndWriteTmpClassFile(String fileName) throws IOException {
+        //create a temp class file
+        File classTypeFile = new File(tmpBaseDir, fileName);
+
+        //write it
+        BufferedWriter bw = new BufferedWriter(new FileWriter(classTypeFile));
+        bw.write("This is the temporary file content");
+        bw.close();
+
+        return classTypeFile;
+    }
+
+    private class ClassLoaderMock extends ClassLoader {
+
+        private String libraryFilePath;
+
+        private ClassLoaderMock(String libraryFilePath) {
+            this.libraryFilePath = libraryFilePath;
+        }
+
+        @Override
+        public Enumeration<URL> getResources(String name) {
+            Vector<URL> urlVector = new Vector<URL>();
+            try {
+                urlVector.add(new URL("jar:file:" + libraryFilePath + "!/com/mysema/codegen/model/"));
+            } catch (MalformedURLException e) {
+                fail("File " + libraryFilePath + " not found!");
+            }
+            return urlVector.elements();
+        }
+    }
+}

--- a/template.mf
+++ b/template.mf
@@ -5,5 +5,6 @@ Bundle-ManifestVersion: 2
 Import-Template:  
   javax.annotation.*;version="0",  
   javax.tools.*;version="0",
+  javax.lang.*;version="0",
   org.eclipse.jdt.*;version="3.7.2",
   com.google.common.*;version="${guava.version}"


### PR DESCRIPTION
#28 Fixed classpath build when the classloader contains jar URIs. MemFileManager can now list Java class files that are packaged in a JAR.

This PR aims to fix the bugs:
- https://github.com/querydsl/codegen/issues/28
- https://github.com/querydsl/codegen/issues/42
- https://github.com/querydsl/querydsl/issues/1407

Side note
Most of the help for this code came from here: http://atamur.blogspot.ie/2009/10/using-built-in-javacompiler-with-custom.html