### PR TITLE
Recognize Java versions greater than 1.8

### DIFF
--- a/src/main/java/com/mysema/codegen/ECJEvaluatorFactory.java
+++ b/src/main/java/com/mysema/codegen/ECJEvaluatorFactory.java
@@ -62,7 +62,12 @@ public class ECJEvaluatorFactory extends AbstractEvaluatorFactory {
     
     public static CompilerOptions getDefaultCompilerOptions() {
         String javaSpecVersion = System.getProperty("java.specification.version");
-        if (javaSpecVersion.equals("1.8")) {
+        if (javaSpecVersion.equals("1.8")
+                || javaSpecVersion.equals("9")
+                || javaSpecVersion.equals("10")
+                || javaSpecVersion.equals("11")
+                || javaSpecVersion.equals("12"))
+        {
             javaSpecVersion = "1.7";
         }
         Map<String, Object> settings = Maps.newHashMap();


### PR DESCRIPTION
Fix errors when using QueryDSL with JDK version 9 or higher.
Example error : "parameterized types are only available if source level is 1.5 or greater"
Root cause: codegen does not recognize the new Java versioning scheme (JDK 8: "1.8", JDK 9: "9").
Perhaps there exists a better fix but for our purposes this was the simplest workaround.

